### PR TITLE
[DO NOT MERGE] Upgrade GitLab API from v3 to v4

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ npm install gitlab
 Usage
 =====
 
-URL to your GitLab instance should not include `/api/v3` path.
+URL to your GitLab instance should not include `/api/v4` path.
 
 Coffee-Script
 -------------

--- a/lib/ApiBaseHTTP.js
+++ b/lib/ApiBaseHTTP.js
@@ -46,7 +46,7 @@
       if ((base2 = this.options.slumber).append_slash == null) {
         base2.append_slash = false;
       }
-      this.options.url = this.options.url.replace(/\/api\/v3/, '');
+      this.options.url = this.options.url.replace(/\/api\/v4/, '');
       if (this.options.auth != null) {
         this.options.slumber.auth = this.options.auth;
       }

--- a/lib/ApiV4.js
+++ b/lib/ApiV4.js
@@ -4,25 +4,25 @@
     extend = function(child, parent) { for (var key in parent) { if (hasProp.call(parent, key)) child[key] = parent[key]; } function ctor() { this.constructor = child; } ctor.prototype = parent.prototype; child.prototype = new ctor(); child.__super__ = parent.prototype; return child; },
     hasProp = {}.hasOwnProperty;
 
-  debug = require('debug')('gitlab:ApiV3');
+  debug = require('debug')('gitlab:ApiV4');
 
   ApiBaseHTTP = require('./ApiBaseHTTP').ApiBaseHTTP;
 
-  module.exports.ApiV3 = (function(superClass) {
-    extend(ApiV3, superClass);
+  module.exports.ApiV4 = (function(superClass) {
+    extend(ApiV4, superClass);
 
-    function ApiV3() {
+    function ApiV4() {
       this.handleOptions = bind(this.handleOptions, this);
-      return ApiV3.__super__.constructor.apply(this, arguments);
+      return ApiV4.__super__.constructor.apply(this, arguments);
     }
 
-    ApiV3.prototype.handleOptions = function() {
-      ApiV3.__super__.handleOptions.apply(this, arguments);
-      this.options.base_url = 'api/v3';
+    ApiV4.prototype.handleOptions = function() {
+      ApiV4.__super__.handleOptions.apply(this, arguments);
+      this.options.base_url = 'api/v4';
       return debug("handleOptions()");
     };
 
-    return ApiV3;
+    return ApiV4;
 
   })(ApiBaseHTTP);
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,12 +1,12 @@
 (function() {
-  var ApiV3;
+  var ApiV4;
 
-  ApiV3 = require('./ApiV3').ApiV3;
+  ApiV4 = require('./ApiV4').ApiV4;
 
   module.exports = function(options) {
-    return new ApiV3(options);
+    return new ApiV4(options);
   };
 
-  module.exports.ApiV3 = ApiV3;
+  module.exports.ApiV4 = ApiV4;
 
 }).call(this);

--- a/src/ApiBaseHTTP.coffee
+++ b/src/ApiBaseHTTP.coffee
@@ -18,7 +18,7 @@ class module.exports.ApiBaseHTTP extends ApiBase
     @options.slumber ?= {}
     @options.slumber.append_slash ?= false
 
-    @options.url = @options.url.replace(/\/api\/v3/, '')
+    @options.url = @options.url.replace(/\/api\/v4/, '')
 
     if @options.auth?
       @options.slumber.auth = @options.auth

--- a/src/ApiV3.coffee
+++ b/src/ApiV3.coffee
@@ -1,8 +1,0 @@
-debug = require('debug') 'gitlab:ApiV3'
-{ApiBaseHTTP} = require './ApiBaseHTTP'
-
-class module.exports.ApiV3 extends ApiBaseHTTP
-  handleOptions: =>
-    super
-    @options.base_url = 'api/v3'
-    debug "handleOptions()"

--- a/src/ApiV4.coffee
+++ b/src/ApiV4.coffee
@@ -1,0 +1,8 @@
+debug = require('debug') 'gitlab:ApiV4'
+{ApiBaseHTTP} = require './ApiBaseHTTP'
+
+class module.exports.ApiV4 extends ApiBaseHTTP
+  handleOptions: =>
+    super
+    @options.base_url = 'api/v4'
+    debug "handleOptions()"

--- a/src/index.coffee
+++ b/src/index.coffee
@@ -1,5 +1,5 @@
-{ApiV3} = require './ApiV3'
+{ApiV4} = require './ApiV4'
 module.exports = (options) ->
-	return new ApiV3(options)
+	return new ApiV4(options)
 
-module.exports.ApiV3 = ApiV3
+module.exports.ApiV4 = ApiV4

--- a/tests/ApiBaseHTTP.test.coffee
+++ b/tests/ApiBaseHTTP.test.coffee
@@ -16,17 +16,17 @@ describe "ApiBaseHTTP", ->
   beforeEach ->
 
   describe "handleOptions()", ->
-    it "should strip /api/v3 from `url` parameter if provided", ->
+    it "should strip /api/v4 from `url` parameter if provided", ->
       apibasehttp = new ApiBaseHTTP
-        base_url: "api/v3"
-        url: "http://gitlab.mydomain.com/api/v3"
+        base_url: "api/v4"
+        url: "http://gitlab.mydomain.com/api/v4"
         token: "test"
 
       expect(apibasehttp.options.url).to.equal("http://gitlab.mydomain.com")
 
-    it "should not strip /api/v3 from `url` parameter if not provided", ->
+    it "should not strip /api/v4 from `url` parameter if not provided", ->
       apibasehttp = new ApiBaseHTTP
-        base_url: "api/v3"
+        base_url: "api/v4"
         url: "http://gitlab.mydomain.com"
         token: "test"
 

--- a/tests/ApiBaseHTTP.test.js
+++ b/tests/ApiBaseHTTP.test.js
@@ -22,17 +22,17 @@
     });
     beforeEach(function() {});
     return describe("handleOptions()", function() {
-      it("should strip /api/v3 from `url` parameter if provided", function() {
+      it("should strip /api/v4 from `url` parameter if provided", function() {
         apibasehttp = new ApiBaseHTTP({
-          base_url: "api/v3",
-          url: "http://gitlab.mydomain.com/api/v3",
+          base_url: "api/v4",
+          url: "http://gitlab.mydomain.com/api/v4",
           token: "test"
         });
         return expect(apibasehttp.options.url).to.equal("http://gitlab.mydomain.com");
       });
-      return it("should not strip /api/v3 from `url` parameter if not provided", function() {
+      return it("should not strip /api/v4 from `url` parameter if not provided", function() {
         apibasehttp = new ApiBaseHTTP({
-          base_url: "api/v3",
+          base_url: "api/v4",
           url: "http://gitlab.mydomain.com",
           token: "test"
         });


### PR DESCRIPTION
From https://docs.gitlab.com/ce/api/v3_to_v4.html ... 

## Endpoints under GET /projects/merge_request/:id have been removed (use: GET /projects/merge_requests/:id) !8793

- So this shouldn’t affect us since we only use `gitLabApi.projects.merge_requests.add` and `gitLabApi.projects.merge_requests.list` which use `projects/merge_requests/` instead of `projects/merge_request/`, but we might want to change `node-gitlab/src/Models/ProjectMergeRequests.coffee` to use merge_request**s** everywhere.\

## Moved POST /projects/fork/:id to POST /projects/:id/fork !8940
- We don't use `fork` currently, but we may want to be proactive and change this now rather than wait until later.


